### PR TITLE
ci: run tests on all branch pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,6 @@ name: Test
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   python-lint:


### PR DESCRIPTION
Fixes #6

## Summary
Enable CI test runs on all branch pushes, not just main and pull requests.

## Problem
The test workflow was restricted to only run on `main` branch pushes and pull requests. This prevented developers from getting CI feedback when pushing to feature branches before opening a PR.

## Changes
- Remove branch restrictions from test workflow to enable CI on all branch pushes

## Test Plan
- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR