### PR TITLE
Add ifaddr for reliable network detection in containers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,6 @@ ai = [
     "transformers>=4.35.0",
     "accelerate>=0.24.0",
 ]
-agentic = [
-    "smolagents[litellm]>=1.0.0",
-]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/obs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "BAC0>=24.0.0",
     "PyYAML>=6.0.1",
+    "ifaddr>=0.2.0",
 ]
 
 [project.optional-dependencies]
@@ -40,6 +41,9 @@ ai = [
     "torch>=2.0.0",
     "transformers>=4.35.0",
     "accelerate>=0.24.0",
+]
+agentic = [
+    "smolagents[litellm]>=1.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/obs/discovery/network.py
+++ b/src/obs/discovery/network.py
@@ -111,7 +111,37 @@ def _detect_interfaces() -> list[_InterfaceInfo]:
     if results:
         return results
 
-    # Method 3: socket (assumes /24)
+    # Method 3: ifaddr (cross-platform, works in containers)
+    try:
+        import ifaddr
+
+        for adapter in ifaddr.get_adapters():
+            if _is_virtual_interface(adapter.name):
+                continue
+            for ip_info in adapter.ips:
+                # Skip IPv6 and loopback
+                if not isinstance(ip_info.ip, str):
+                    continue
+                if ip_info.ip.startswith("127."):
+                    continue
+                prefix = getattr(ip_info, "network_prefix", 24)
+                results.append(
+                    _InterfaceInfo(
+                        iface=adapter.name,
+                        ip=ip_info.ip,
+                        cidr=f"{ip_info.ip}/{prefix}",
+                        method="ifaddr",
+                    )
+                )
+    except ImportError:
+        logger.debug("ifaddr module not available")
+    except (OSError, ValueError) as e:
+        logger.debug(f"ifaddr method failed: {e}")
+
+    if results:
+        return results
+
+    # Method 4: socket (assumes /24)
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
             s.connect(("8.8.8.8", 80))
@@ -161,10 +191,16 @@ def auto_detect_client_ip(device_address: str | None = None) -> str:
             if result.returncode == 0 and "src" in result.stdout:
                 parts = result.stdout.split()
                 src_ip = parts[parts.index("src") + 1]
+                # Look up actual prefix from interfaces
+                prefix = 24  # fallback
+                for iface in _detect_interfaces():
+                    if iface.ip == src_ip:
+                        prefix = int(iface.cidr.split("/")[1])
+                        break
                 logger.info(
-                    f"Auto-detected client IP via route to {device_address}: {src_ip}/24"
+                    f"Auto-detected client IP via route to {device_address}: {src_ip}/{prefix}"
                 )
-                return f"{src_ip}/24"
+                return f"{src_ip}/{prefix}"
         except FileNotFoundError:
             logger.debug("'ip' command not available")
         except (OSError, subprocess.SubprocessError, ValueError) as e:

--- a/tests/discovery/test_network.py
+++ b/tests/discovery/test_network.py
@@ -33,12 +33,24 @@ def test_auto_detect_client_ip_prefers_route_lookup(monkeypatch) -> None:
         )
 
     monkeypatch.setattr(network_module.subprocess, "run", _fake_run)
+    monkeypatch.setattr(
+        network_module,
+        "_detect_interfaces",
+        lambda: [
+            network_module._InterfaceInfo(
+                iface="en0",
+                ip="10.0.0.2",
+                cidr="10.0.0.2/22",  # non-/24 to verify lookup
+                method="ip_addr",
+            )
+        ],
+    )
 
     # when
     client_ip = network_module.auto_detect_client_ip("10.0.0.9")
 
     # then
-    assert client_ip == "10.0.0.2/24"
+    assert client_ip == "10.0.0.2/22"
 
 
 def test_auto_detect_client_ip_falls_back_to_detected_interfaces(monkeypatch) -> None:


### PR DESCRIPTION
Fixes #8

## Summary
Add ifaddr for reliable network/subnet detection in containerized environments.

## Problem
The socket fallback method assumed `/24` subnet masks, which caused BACnet broadcast issues in Docker networks with different subnet masks (e.g., `/16`). This led to incorrect broadcast address calculations and failed device discovery.

## Changes
- Add `ifaddr` as a core dependency for cross-platform subnet detection
- Add ifaddr-based detection method before socket fallback in `_detect_interfaces()`
- Fix route-based detection to look up actual prefix instead of assuming `/24`

## Test Plan
- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR