### PR TITLE
feat: add BACnet point value reading operations 

### DIFF
--- a/src/obs/discovery/__init__.py
+++ b/src/obs/discovery/__init__.py
@@ -15,6 +15,8 @@ from .scan import (
     discover_objects_sync,
     full_scan,
     full_scan_sync,
+    read_points,
+    read_points_sync,
     scan_network,
     scan_network_sync,
 )
@@ -22,6 +24,7 @@ from .types import (
     DiscoveryFullScanResult,
     DiscoveryNetworkScanResult,
     DiscoveryObjectsResult,
+    ReadPointsResult,
 )
 
 __all__ = [
@@ -32,6 +35,9 @@ __all__ = [
     "discover_objects_sync",
     "full_scan",
     "full_scan_sync",
+    # Read functions
+    "read_points",
+    "read_points_sync",
     # Graph types
     "Node",
     "Edge",
@@ -46,4 +52,5 @@ __all__ = [
     "DiscoveryNetworkScanResult",
     "DiscoveryObjectsResult",
     "DiscoveryFullScanResult",
+    "ReadPointsResult",
 ]

--- a/src/obs/discovery/bacnet/controller/core.py
+++ b/src/obs/discovery/bacnet/controller/core.py
@@ -12,11 +12,12 @@ from typing import Any
 from .census import CensusMixin
 from .network_scan import NetworkScanMixin
 from .object_scan import ObjectScanMixin
+from .read import ReadMixin
 
 logger = logging.getLogger(__name__)
 
 
-class BACnetController(NetworkScanMixin, CensusMixin, ObjectScanMixin):
+class BACnetController(NetworkScanMixin, CensusMixin, ObjectScanMixin, ReadMixin):
     """Singleton BAC0 wrapper for all BACnet operations."""
 
     def __init__(

--- a/src/obs/discovery/bacnet/controller/read.py
+++ b/src/obs/discovery/bacnet/controller/read.py
@@ -1,0 +1,246 @@
+"""BACnet point value reading operations."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from ..types import BACnetDeviceIdentifier, BACnetObject, BACnetObjectIdentifier
+from .constants import BACNET_ERRORS
+
+logger = logging.getLogger(__name__)
+
+
+class ReadMixin:
+    """Point value reading operations."""
+
+    _initialized: bool
+    bacnet: Any
+    _semaphore: asyncio.Semaphore
+
+    async def read_point(
+        self,
+        device_address: str,
+        device_id: int,
+        object_type: str,
+        instance: int,
+        timeout: float = 5.0,
+    ) -> BACnetObject | None:
+        """Read a single BACnet point's present value.
+
+        Args:
+            device_address: IP address of the BACnet device.
+            device_id: BACnet device ID.
+            object_type: Object type (e.g., "analogValue").
+            instance: Object instance number.
+            timeout: Read timeout in seconds.
+
+        Returns:
+            BACnetObject with current value, or None if read failed.
+        """
+        if not self._initialized:
+            await self.initialize()  # type: ignore[attr-defined]
+        if self.bacnet is None:
+            raise RuntimeError("BACnet controller not initialized")
+
+        async with self._semaphore:
+            return await self._read_point_unlocked(
+                device_address, device_id, object_type, instance, timeout
+            )
+
+    async def _read_point_unlocked(
+        self,
+        device_address: str,
+        device_id: int,
+        object_type: str,
+        instance: int,
+        timeout: float = 5.0,
+    ) -> BACnetObject | None:
+        """Read a single point without semaphore (for internal batch use)."""
+        try:
+            # Read presentValue
+            value = await asyncio.wait_for(
+                self.bacnet.read(
+                    f"{device_address} {object_type}:{instance} presentValue"
+                ),
+                timeout=timeout,
+            )
+
+            # Optionally read name for context
+            name: str | None = None
+            try:
+                name_raw = await asyncio.wait_for(
+                    self.bacnet.read(
+                        f"{device_address} {object_type}:{instance} objectName"
+                    ),
+                    timeout=3.0,
+                )
+                name = str(name_raw) if name_raw else None
+            except BACNET_ERRORS:
+                pass
+
+            # Read units for analog objects
+            units: str | None = None
+            unit_id: str | None = None
+            if object_type.startswith("analog"):
+                try:
+                    units_code = await asyncio.wait_for(
+                        self.bacnet.read(
+                            f"{device_address} {object_type}:{instance} units"
+                        ),
+                        timeout=3.0,
+                    )
+                    units = str(units_code) if units_code is not None else None
+                    unit_id = self._unit_id(units_code)  # type: ignore[attr-defined]
+                except BACNET_ERRORS:
+                    pass
+
+            device_identifier = BACnetDeviceIdentifier(
+                address=device_address,
+                device_id=device_id,
+            )
+            object_identifier = BACnetObjectIdentifier(
+                object_type=object_type,
+                instance=instance,
+            )
+            return BACnetObject(
+                uid=self._build_object_uid(  # type: ignore[attr-defined]
+                    device_address, device_id, object_type, instance
+                ),
+                device=device_identifier,
+                object_identifier=object_identifier,
+                name=name,
+                value=self._to_native(value),  # type: ignore[attr-defined]
+                units=units,
+                unit_id=unit_id,
+                metadata={"source": "read_point"},
+            )
+        except BACNET_ERRORS as exc:
+            logger.debug(
+                "Error reading %s:%d from %s:%d: %s",
+                object_type,
+                instance,
+                device_address,
+                device_id,
+                exc,
+            )
+            return None
+
+    async def read_points(
+        self,
+        device_address: str,
+        device_id: int,
+        points: list[tuple[str, int]],
+        timeout: float = 10.0,
+    ) -> list[BACnetObject | None]:
+        """Read multiple BACnet point values using RPM with fallback.
+
+        Args:
+            device_address: IP address of the BACnet device.
+            device_id: BACnet device ID.
+            points: List of (object_type, instance) tuples to read.
+            timeout: RPM timeout in seconds.
+
+        Returns:
+            List of BACnetObject (or None for failed reads), same order as input.
+        """
+        if not self._initialized:
+            await self.initialize()  # type: ignore[attr-defined]
+        if self.bacnet is None:
+            raise RuntimeError("BACnet controller not initialized")
+
+        if not points:
+            return []
+
+        results: list[BACnetObject | None] = [None] * len(points)
+
+        # Try RPM first for efficiency
+        rpm_objects = {}
+        for obj_type, instance in points:
+            rpm_objects[f"{obj_type}:{instance}"] = [
+                "presentValue",
+                "objectName",
+                "units",
+            ]
+
+        rpm_result = await self.read_multiple(device_address, rpm_objects, timeout)  # type: ignore[attr-defined]
+
+        failed_indices: list[int] = []
+        if rpm_result is not None:
+            # Build normalized lookup
+            norm_lookup: dict[str, dict[str, Any]] = {}
+            for raw_key, raw_value in rpm_result.items():
+                if not isinstance(raw_value, dict):
+                    continue
+                norm_lookup[raw_key] = raw_value
+                if ":" in raw_key:
+                    prefix, suffix = raw_key.rsplit(":", maxsplit=1)
+                    normalized = self._normalize_object_type(prefix) + ":" + suffix  # type: ignore[attr-defined]
+                    norm_lookup[normalized] = raw_value
+
+            for idx, (obj_type, instance) in enumerate(points):
+                key = f"{obj_type}:{instance}"
+                props = norm_lookup.get(key)
+                if props is not None:
+                    results[idx] = self._build_read_result(
+                        device_address=device_address,
+                        device_id=device_id,
+                        object_type=obj_type,
+                        instance=instance,
+                        props=props,
+                    )
+                else:
+                    failed_indices.append(idx)
+        else:
+            # RPM not supported, fall back to individual reads
+            failed_indices = list(range(len(points)))
+
+        # Individual reads for failures
+        if failed_indices:
+            logger.debug(
+                "Individual reads for %d points on %s",
+                len(failed_indices),
+                device_address,
+            )
+
+            async def _read_single(idx: int) -> None:
+                async with self._semaphore:
+                    obj_type, instance = points[idx]
+                    results[idx] = await self._read_point_unlocked(
+                        device_address, device_id, obj_type, instance
+                    )
+
+            await asyncio.gather(*[_read_single(idx) for idx in failed_indices])
+
+        return results
+
+    def _build_read_result(
+        self,
+        *,
+        device_address: str,
+        device_id: int,
+        object_type: str,
+        instance: int,
+        props: dict[str, Any],
+    ) -> BACnetObject:
+        """Build BACnetObject from RPM read result."""
+        device_identifier = BACnetDeviceIdentifier(
+            address=device_address, device_id=device_id
+        )
+        object_identifier = BACnetObjectIdentifier(
+            object_type=object_type, instance=instance
+        )
+        raw_units = props.get("units")
+        return BACnetObject(
+            uid=self._build_object_uid(  # type: ignore[attr-defined]
+                device_address, device_id, object_type, instance
+            ),
+            device=device_identifier,
+            object_identifier=object_identifier,
+            name=str(props.get("objectName")) if props.get("objectName") else None,
+            value=self._to_native(props.get("presentValue")),  # type: ignore[attr-defined]
+            units=str(raw_units) if raw_units is not None else None,
+            unit_id=self._unit_id(raw_units),  # type: ignore[attr-defined]
+            metadata={"source": "rpm_read"},
+        )

--- a/src/obs/discovery/bacnet/scan.py
+++ b/src/obs/discovery/bacnet/scan.py
@@ -14,6 +14,8 @@ from .types import (
     BACnetObjectIdentifier,
     BACnetObjectsDiscoveryInput,
     BACnetObjectsDiscoveryResult,
+    BACnetReadInput,
+    BACnetReadResult,
     BACnetScanTimings,
 )
 
@@ -32,6 +34,8 @@ __all__ = [
     "scan_bacnet_network_sync",
     "discover_bacnet_objects",
     "discover_bacnet_objects_sync",
+    "read_bacnet_points",
+    "read_bacnet_points_sync",
 ]
 
 
@@ -176,4 +180,95 @@ def discover_bacnet_objects_sync(
             max_instance=max_instance,
         ),
         timeout=BACNET_OPERATION_TIMEOUT,
+    )
+
+
+async def read_bacnet_points(
+    device_address: str,
+    device_id: int,
+    points: list[tuple[str, int]],
+    *,
+    client_ip: str | None = None,
+    bbmd_ip: str | None = None,
+    timeout: float = 30.0,
+) -> BACnetReadResult:
+    """Read current values from BACnet points.
+
+    Args:
+        device_address: IP address of the BACnet device.
+        device_id: BACnet device ID.
+        points: List of (object_type, instance) tuples to read.
+        client_ip: Optional client IP for BACnet communication.
+        bbmd_ip: Optional BBMD IP for BACnet routing.
+        timeout: Read timeout in seconds.
+
+    Returns:
+        BACnetReadResult with list of BACnetObject containing current values.
+    """
+    device_identifier = BACnetDeviceIdentifier(
+        address=device_address, device_id=device_id
+    )
+    point_identifiers = [
+        BACnetObjectIdentifier(object_type=obj_type, instance=instance)
+        for obj_type, instance in points
+    ]
+    read_input = BACnetReadInput(
+        device=device_identifier,
+        points=point_identifiers,
+        client_ip=client_ip,
+        bbmd_ip=bbmd_ip,
+    )
+    started = utc_now()
+
+    try:
+        controller = get_bacnet_controller(client_ip=client_ip, bbmd_ip=bbmd_ip)
+        if not controller._initialized:
+            await controller.initialize()
+
+        results = await controller.read_points(
+            device_address,
+            device_id,
+            points,
+            timeout=timeout,
+        )
+        # Filter out None results
+        data = [obj for obj in results if obj is not None]
+        finished = utc_now()
+        return BACnetReadResult(
+            input=read_input,
+            data=data,
+            timings=_timings(started, finished),
+            success=True,
+        )
+    except _SCAN_FAILURES as exc:
+        finished = utc_now()
+        return BACnetReadResult(
+            input=read_input,
+            data=[],
+            timings=_timings(started, finished),
+            success=False,
+            error=str(exc),
+        )
+
+
+def read_bacnet_points_sync(
+    device_address: str,
+    device_id: int,
+    points: list[tuple[str, int]],
+    *,
+    client_ip: str | None = None,
+    bbmd_ip: str | None = None,
+    timeout: float = 30.0,
+) -> BACnetReadResult:
+    """Synchronous wrapper for read_bacnet_points()."""
+    return run_sync(
+        read_bacnet_points(
+            device_address,
+            device_id,
+            points,
+            client_ip=client_ip,
+            bbmd_ip=bbmd_ip,
+            timeout=timeout,
+        ),
+        timeout=timeout + 30,
     )

--- a/src/obs/discovery/bacnet/types.py
+++ b/src/obs/discovery/bacnet/types.py
@@ -15,6 +15,8 @@ __all__ = [
     "BACnetObjectsDiscoveryInput",
     "BACnetNetworkScanResult",
     "BACnetObjectsDiscoveryResult",
+    "BACnetReadInput",
+    "BACnetReadResult",
 ]
 
 
@@ -109,6 +111,27 @@ class BACnetObjectsDiscoveryResult:
     """Result wrapper for device-level BACnet object discovery."""
 
     input: BACnetObjectsDiscoveryInput
+    data: list[BACnetObject]
+    timings: BACnetScanTimings
+    success: bool
+    error: str | None = None
+
+
+@dataclass(slots=True)
+class BACnetReadInput:
+    """Inputs for BACnet point value reading."""
+
+    device: BACnetDeviceIdentifier
+    points: list[BACnetObjectIdentifier]
+    client_ip: str | None = None
+    bbmd_ip: str | None = None
+
+
+@dataclass(slots=True)
+class BACnetReadResult:
+    """Result wrapper for BACnet point value reading."""
+
+    input: BACnetReadInput
     data: list[BACnetObject]
     timings: BACnetScanTimings
     success: bool

--- a/src/obs/discovery/scan.py
+++ b/src/obs/discovery/scan.py
@@ -22,8 +22,12 @@ from .types import (
     DiscoveryObjectsInput,
     DiscoveryObjectsResult,
     EntityKind,
+    Point,
     Protocol,
     ProtocolRef,
+    ReadPointsData,
+    ReadPointsInput,
+    ReadPointsResult,
 )
 
 __all__ = [
@@ -33,6 +37,8 @@ __all__ = [
     "discover_objects_sync",
     "full_scan",
     "full_scan_sync",
+    "read_points",
+    "read_points_sync",
 ]
 
 logger = logging.getLogger(__name__)
@@ -540,4 +546,166 @@ def full_scan_sync(
             **kwargs,
         ),
         timeout=600,
+    )
+
+
+async def read_points(
+    device: str,
+    points: list[tuple[str, int]],
+    *,
+    network: str | None = None,
+    strict: bool = False,
+    **kwargs: Any,
+) -> ReadPointsResult:
+    """Read current values from device points.
+
+    Args:
+        device: Device identifier in format protocol://address#device_id
+            (e.g., "bacnet://192.168.1.100#1234").
+        points: List of (object_type, instance) tuples to read.
+        network: Optional network specification.
+        strict: If True, raise on resolution failures.
+        **kwargs: Additional protocol-specific options (client_ip, bbmd_ip, etc.)
+
+    Returns:
+        ReadPointsResult with list of Point objects containing current values.
+    """
+    started = utc_now()
+
+    input_data = ReadPointsInput(
+        device=device,
+        points=points,
+        network=network,
+        strict=strict,
+        metadata=dict(kwargs),
+    )
+
+    try:
+        resolved_network = _resolve_network(network, strict=strict)
+    except RuntimeError as exc:
+        finished = utc_now()
+        detail = _error("network_resolution_failed", str(exc), device=device)
+        return ReadPointsResult(
+            input=input_data,
+            data=ReadPointsData(points=[]),
+            timings=timings(started, finished),
+            success=False,
+            errors=[detail.message],
+            error_details=[detail],
+            metadata=scan_context(client_ip=None),
+        )
+
+    provided_client_ip = kwargs.get("client_ip")
+    try:
+        default_client_ip = _resolve_client_ip(
+            client_ip=provided_client_ip, strict=strict
+        )
+    except RuntimeError as exc:
+        finished = utc_now()
+        detail = _error("client_ip_resolution_failed", str(exc), device=device)
+        return ReadPointsResult(
+            input=input_data,
+            data=ReadPointsData(points=[]),
+            timings=timings(started, finished),
+            success=False,
+            errors=[detail.message],
+            error_details=[detail],
+            metadata=scan_context(client_ip=None),
+        )
+
+    errors: list[str] = []
+    error_details: list[DiscoveryError] = []
+
+    try:
+        protocol, address, device_id = parse_device_identifier(device)
+    except ValueError as exc:
+        finished = utc_now()
+        return ReadPointsResult(
+            input=input_data,
+            data=ReadPointsData(points=[]),
+            timings=timings(started, finished),
+            success=False,
+            errors=[str(exc)],
+            error_details=[
+                _error("invalid_device_identifier", str(exc), device=device)
+            ],
+            metadata=scan_context(client_ip=default_client_ip),
+        )
+
+    client_ip = (
+        provided_client_ip
+        if provided_client_ip
+        else _resolve_client_ip(client_ip=None, device_address=address, strict=strict)
+    )
+
+    read_points_list: list[Point] = []
+
+    try:
+        if protocol == Protocol.BACNET:
+            from .bacnet.scan import read_bacnet_points
+
+            raw_result = await read_bacnet_points(
+                address,
+                int(device_id),
+                points,
+                client_ip=client_ip,
+                **{k: v for k, v in kwargs.items() if k != "client_ip"},
+            )
+            if not raw_result.success:
+                message = raw_result.error or "BACnet point read failed"
+                errors.append(message)
+                error_details.append(
+                    _error(
+                        "protocol_read_failed",
+                        message,
+                        protocol=protocol.value,
+                        device=device,
+                    )
+                )
+
+            # Convert BACnetObject to Point
+            read_points_list = [
+                bacnet_object_to_point(obj, network=resolved_network)
+                for obj in raw_result.data
+            ]
+        else:
+            raise ValueError(f"Unsupported protocol: {protocol}")
+    except (RuntimeError, ValueError, TypeError, AttributeError) as exc:
+        errors.append(str(exc))
+        error_details.append(
+            _error(
+                "read_error",
+                str(exc),
+                protocol=protocol.value,
+                device=device,
+            )
+        )
+
+    finished = utc_now()
+
+    return ReadPointsResult(
+        input=input_data,
+        data=ReadPointsData(points=read_points_list),
+        timings=timings(started, finished),
+        success=not errors,
+        errors=errors,
+        error_details=error_details,
+        metadata=scan_context(client_ip=client_ip),
+    )
+
+
+def read_points_sync(
+    device: str,
+    points: list[tuple[str, int]],
+    *,
+    network: str | None = None,
+    strict: bool = False,
+    **kwargs: Any,
+) -> ReadPointsResult:
+    """Synchronous wrapper for read_points()."""
+    from .bacnet._loop import run_sync
+
+    return run_sync(
+        read_points(device, points, network=network, strict=strict, **kwargs),
+        timeout=60,
     )

--- a/src/obs/discovery/types.py
+++ b/src/obs/discovery/types.py
@@ -23,6 +23,9 @@ __all__ = [
     "DiscoveryNetworkScanResult",
     "DiscoveryObjectsResult",
     "DiscoveryFullScanResult",
+    "ReadPointsInput",
+    "ReadPointsData",
+    "ReadPointsResult",
 ]
 
 
@@ -159,6 +162,37 @@ class DiscoveryObjectsResult:
 class DiscoveryFullScanResult:
     input: DiscoveryFullScanInput
     data: DiscoveryFullScanData
+    timings: DiscoveryScanTimings
+    success: bool
+    errors: list[str] = field(default_factory=list)
+    error_details: list[DiscoveryError] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ReadPointsInput:
+    """Input for point value reading."""
+
+    device: str
+    points: list[tuple[str, int]]
+    network: str | None = None
+    strict: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ReadPointsData:
+    """Data returned from point reading."""
+
+    points: list[Point]
+
+
+@dataclass(slots=True)
+class ReadPointsResult:
+    """Result wrapper for point value reading."""
+
+    input: ReadPointsInput
+    data: ReadPointsData
     timings: DiscoveryScanTimings
     success: bool
     errors: list[str] = field(default_factory=list)

--- a/tests/discovery/bacnet/test_controller.py
+++ b/tests/discovery/bacnet/test_controller.py
@@ -1111,3 +1111,333 @@ def test_clear_controller_cache_outer_exception_branch(monkeypatch) -> None:
 
     # then
     assert controller_module._bacnet_controller is None
+
+
+# --- ReadMixin tests ---
+
+
+def test_read_point_success(
+    initialized_controller: BACnetController, bacnet_mock: Mock
+) -> None:
+    # given
+    bacnet_mock.read = AsyncMock(side_effect=[72.5, "Zone Temp", 62])
+
+    # when
+    result = asyncio.run(
+        initialized_controller.read_point(
+            "192.168.1.10", 1001, "analogValue", 1, timeout=5.0
+        )
+    )
+
+    # then
+    assert result is not None
+    assert result.value == 72.5
+    assert result.name == "Zone Temp"
+    assert result.units == "62"
+    assert result.object_identifier.object_type == "analogValue"
+    assert result.object_identifier.instance == 1
+    assert result.metadata == {"source": "read_point"}
+
+
+def test_read_point_initializes_when_needed(monkeypatch) -> None:
+    # given
+    controller = BACnetController(client_ip="1.1.1.1/24")
+    controller.bacnet = Mock()
+    controller.bacnet.read = AsyncMock(side_effect=[42.0, "Name", 62])
+    controller._initialized = False
+    monkeypatch.setattr(controller, "initialize", AsyncMock(return_value=True))
+
+    # when
+    result = asyncio.run(controller.read_point("1.2.3.4", 10, "analogInput", 1))
+
+    # then
+    assert result is not None
+    controller.initialize.assert_awaited_once()
+
+
+def test_read_point_raises_when_bacnet_none(monkeypatch) -> None:
+    # given
+    controller = BACnetController(client_ip="1.1.1.1/24")
+    controller._initialized = False
+    controller.bacnet = None
+    monkeypatch.setattr(controller, "initialize", AsyncMock(return_value=True))
+
+    # when / then
+    try:
+        asyncio.run(controller.read_point("1.2.3.4", 10, "analogInput", 1))
+        assert False, "Expected RuntimeError"
+    except RuntimeError as exc:
+        assert "not initialized" in str(exc)
+
+
+def test_read_point_unlocked_returns_none_on_error(
+    initialized_controller: BACnetController, bacnet_mock: Mock
+) -> None:
+    # given
+    bacnet_mock.read = AsyncMock(side_effect=RuntimeError("read failed"))
+
+    # when
+    result = asyncio.run(
+        initialized_controller._read_point_unlocked(
+            "192.168.1.10", 1001, "analogValue", 1
+        )
+    )
+
+    # then
+    assert result is None
+
+
+def test_read_point_unlocked_handles_optional_property_failures(
+    initialized_controller: BACnetController, bacnet_mock: Mock
+) -> None:
+    # given
+    # presentValue succeeds, name fails, units fails
+    bacnet_mock.read = AsyncMock(
+        side_effect=[55.0, RuntimeError("no name"), RuntimeError("no units")]
+    )
+
+    # when
+    result = asyncio.run(
+        initialized_controller._read_point_unlocked(
+            "192.168.1.10", 1001, "analogValue", 1
+        )
+    )
+
+    # then
+    assert result is not None
+    assert result.value == 55.0
+    assert result.name is None
+    assert result.units is None
+
+
+def test_read_point_unlocked_skips_units_for_binary(
+    initialized_controller: BACnetController, bacnet_mock: Mock
+) -> None:
+    # given
+    bacnet_mock.read = AsyncMock(side_effect=[True, "Binary Point"])
+
+    # when
+    result = asyncio.run(
+        initialized_controller._read_point_unlocked(
+            "192.168.1.10", 1001, "binaryInput", 1
+        )
+    )
+
+    # then
+    assert result is not None
+    assert result.value is True
+    assert result.units is None
+    # Only 2 reads: presentValue and objectName (no units for binary)
+    assert bacnet_mock.read.await_count == 2
+
+
+def test_read_points_with_rpm_success(
+    initialized_controller: BACnetController, monkeypatch
+) -> None:
+    # given
+    rpm_result = {
+        "analogValue:1": {
+            "presentValue": 72.5,
+            "objectName": "Zone Temp",
+            "units": 62,
+        },
+        "analogValue:2": {
+            "presentValue": 45.0,
+            "objectName": "Setpoint",
+            "units": 62,
+        },
+    }
+    monkeypatch.setattr(
+        initialized_controller, "read_multiple", AsyncMock(return_value=rpm_result)
+    )
+
+    # when
+    result = asyncio.run(
+        initialized_controller.read_points(
+            "192.168.1.10", 1001, [("analogValue", 1), ("analogValue", 2)]
+        )
+    )
+
+    # then
+    assert len(result) == 2
+    assert result[0] is not None
+    assert result[0].value == 72.5
+    assert result[0].name == "Zone Temp"
+    assert result[0].metadata == {"source": "rpm_read"}
+    assert result[1] is not None
+    assert result[1].value == 45.0
+
+
+def test_read_points_falls_back_to_individual_on_rpm_failure(
+    initialized_controller: BACnetController, monkeypatch, bacnet_mock: Mock
+) -> None:
+    # given
+    monkeypatch.setattr(
+        initialized_controller, "read_multiple", AsyncMock(return_value=None)
+    )
+    # _read_point_unlocked reads: presentValue, objectName, units
+    bacnet_mock.read = AsyncMock(side_effect=[72.5, "Zone Temp", 62])
+
+    # when
+    result = asyncio.run(
+        initialized_controller.read_points("192.168.1.10", 1001, [("analogValue", 1)])
+    )
+
+    # then
+    assert len(result) == 1
+    assert result[0] is not None
+    assert result[0].value == 72.5
+
+
+def test_read_points_falls_back_for_missing_rpm_keys(
+    initialized_controller: BACnetController, monkeypatch, bacnet_mock: Mock
+) -> None:
+    # given
+    # RPM returns only one point, other is missing
+    rpm_result = {
+        "analogValue:1": {
+            "presentValue": 72.5,
+            "objectName": "Zone Temp",
+            "units": 62,
+        },
+    }
+    monkeypatch.setattr(
+        initialized_controller, "read_multiple", AsyncMock(return_value=rpm_result)
+    )
+    bacnet_mock.read = AsyncMock(side_effect=[45.0, "Setpoint", 62])
+
+    # when
+    result = asyncio.run(
+        initialized_controller.read_points(
+            "192.168.1.10", 1001, [("analogValue", 1), ("analogValue", 2)]
+        )
+    )
+
+    # then
+    assert len(result) == 2
+    assert result[0] is not None
+    assert result[0].value == 72.5
+    assert result[1] is not None
+    assert result[1].value == 45.0  # From fallback
+
+
+def test_read_points_returns_empty_for_empty_input(
+    initialized_controller: BACnetController,
+) -> None:
+    # given / when
+    result = asyncio.run(initialized_controller.read_points("192.168.1.10", 1001, []))
+
+    # then
+    assert result == []
+
+
+def test_read_points_initializes_when_needed(monkeypatch) -> None:
+    # given
+    controller = BACnetController(client_ip="1.1.1.1/24")
+    controller.bacnet = Mock()
+    controller._initialized = False
+    monkeypatch.setattr(controller, "initialize", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        controller, "read_multiple", AsyncMock(return_value={"analogValue:1": {}})
+    )
+
+    # when
+    result = asyncio.run(controller.read_points("1.2.3.4", 10, [("analogValue", 1)]))
+
+    # then
+    assert len(result) == 1
+    controller.initialize.assert_awaited_once()
+
+
+def test_read_points_raises_when_bacnet_none(monkeypatch) -> None:
+    # given
+    controller = BACnetController(client_ip="1.1.1.1/24")
+    controller._initialized = False
+    controller.bacnet = None
+    monkeypatch.setattr(controller, "initialize", AsyncMock(return_value=True))
+
+    # when / then
+    try:
+        asyncio.run(controller.read_points("1.2.3.4", 10, [("analogValue", 1)]))
+        assert False, "Expected RuntimeError"
+    except RuntimeError as exc:
+        assert "not initialized" in str(exc)
+
+
+def test_read_points_handles_normalized_rpm_keys(
+    initialized_controller: BACnetController, monkeypatch
+) -> None:
+    # given
+    # RPM returns with hyphenated key format
+    rpm_result = {
+        "analog-value:1": {
+            "presentValue": 72.5,
+            "objectName": "Zone Temp",
+            "units": 62,
+        },
+    }
+    monkeypatch.setattr(
+        initialized_controller, "read_multiple", AsyncMock(return_value=rpm_result)
+    )
+
+    # when
+    result = asyncio.run(
+        initialized_controller.read_points("192.168.1.10", 1001, [("analogValue", 1)])
+    )
+
+    # then
+    assert len(result) == 1
+    assert result[0] is not None
+    assert result[0].value == 72.5
+
+
+def test_build_read_result(initialized_controller: BACnetController) -> None:
+    # given
+    props = {
+        "presentValue": 72.5,
+        "objectName": "Zone Temp",
+        "units": 62,
+    }
+
+    # when
+    result = initialized_controller._build_read_result(
+        device_address="192.168.1.10",
+        device_id=1001,
+        object_type="analogValue",
+        instance=1,
+        props=props,
+    )
+
+    # then
+    assert result.uid == "bacnet://192.168.1.10/1001/analogValue:1"
+    assert result.value == 72.5
+    assert result.name == "Zone Temp"
+    assert result.units == "62"
+    assert result.unit_id == "62"
+    assert result.device.address == "192.168.1.10"
+    assert result.device.device_id == 1001
+    assert result.object_identifier.object_type == "analogValue"
+    assert result.object_identifier.instance == 1
+    assert result.metadata == {"source": "rpm_read"}
+
+
+def test_build_read_result_handles_none_values(
+    initialized_controller: BACnetController,
+) -> None:
+    # given
+    props = {"presentValue": None, "objectName": None, "units": None}
+
+    # when
+    result = initialized_controller._build_read_result(
+        device_address="192.168.1.10",
+        device_id=1001,
+        object_type="binaryInput",
+        instance=1,
+        props=props,
+    )
+
+    # then
+    assert result.value is None
+    assert result.name is None
+    assert result.units is None
+    assert result.unit_id is None

--- a/tests/discovery/bacnet/test_controller.py
+++ b/tests/discovery/bacnet/test_controller.py
@@ -1145,14 +1145,15 @@ def test_read_point_initializes_when_needed(monkeypatch) -> None:
     controller.bacnet = Mock()
     controller.bacnet.read = AsyncMock(side_effect=[42.0, "Name", 62])
     controller._initialized = False
-    monkeypatch.setattr(controller, "initialize", AsyncMock(return_value=True))
+    mock_initialize = AsyncMock(return_value=True)
+    monkeypatch.setattr(controller, "initialize", mock_initialize)
 
     # when
     result = asyncio.run(controller.read_point("1.2.3.4", 10, "analogInput", 1))
 
     # then
     assert result is not None
-    controller.initialize.assert_awaited_once()
+    mock_initialize.assert_awaited_once()
 
 
 def test_read_point_raises_when_bacnet_none(monkeypatch) -> None:
@@ -1336,7 +1337,8 @@ def test_read_points_initializes_when_needed(monkeypatch) -> None:
     controller = BACnetController(client_ip="1.1.1.1/24")
     controller.bacnet = Mock()
     controller._initialized = False
-    monkeypatch.setattr(controller, "initialize", AsyncMock(return_value=True))
+    mock_initialize = AsyncMock(return_value=True)
+    monkeypatch.setattr(controller, "initialize", mock_initialize)
     monkeypatch.setattr(
         controller, "read_multiple", AsyncMock(return_value={"analogValue:1": {}})
     )
@@ -1346,7 +1348,7 @@ def test_read_points_initializes_when_needed(monkeypatch) -> None:
 
     # then
     assert len(result) == 1
-    controller.initialize.assert_awaited_once()
+    mock_initialize.assert_awaited_once()
 
 
 def test_read_points_raises_when_bacnet_none(monkeypatch) -> None:

--- a/tests/discovery/bacnet/test_scan.py
+++ b/tests/discovery/bacnet/test_scan.py
@@ -127,3 +127,99 @@ def test_discover_bacnet_objects_sync_uses_run_sync(monkeypatch) -> None:
 
     # then
     assert result is expected
+
+
+class StubReadController:
+    def __init__(self, initialized: bool = False):
+        self._initialized = initialized
+        self.initialize = AsyncMock(return_value=True)
+        self.read_points = AsyncMock(return_value=[])
+
+
+def test_read_bacnet_points_success(monkeypatch) -> None:
+    # given
+    controller = StubReadController(initialized=False)
+    point = make_bacnet_object(object_type="analogValue", instance=5, value=72.5)
+    controller.read_points.return_value = [point]
+    monkeypatch.setattr(scan_module, "get_bacnet_controller", lambda **_: controller)
+
+    # when
+    result = asyncio.run(
+        scan_module.read_bacnet_points(
+            "192.168.1.10",
+            1001,
+            [("analogValue", 5)],
+            timeout=15.0,
+        )
+    )
+
+    # then
+    assert result.success is True
+    assert result.error is None
+    assert result.data == [point]
+    assert result.input.device == BACnetDeviceIdentifier(
+        address="192.168.1.10",
+        device_id=1001,
+    )
+    assert result.input.points == [
+        BACnetObjectIdentifier(object_type="analogValue", instance=5)
+    ]
+    controller.initialize.assert_awaited_once()
+    controller.read_points.assert_awaited_once_with(
+        "192.168.1.10", 1001, [("analogValue", 5)], timeout=15.0
+    )
+
+
+def test_read_bacnet_points_filters_none_results(monkeypatch) -> None:
+    # given
+    controller = StubReadController(initialized=True)
+    point = make_bacnet_object()
+    controller.read_points.return_value = [point, None, None]
+    monkeypatch.setattr(scan_module, "get_bacnet_controller", lambda **_: controller)
+
+    # when
+    result = asyncio.run(
+        scan_module.read_bacnet_points("192.168.1.10", 1001, [("analogInput", 1)])
+    )
+
+    # then
+    assert result.success is True
+    assert len(result.data) == 1
+    assert result.data[0] == point
+
+
+def test_read_bacnet_points_error(monkeypatch) -> None:
+    # given
+    controller = StubReadController(initialized=True)
+    controller.read_points.side_effect = RuntimeError("read failed")
+    monkeypatch.setattr(scan_module, "get_bacnet_controller", lambda **_: controller)
+
+    # when
+    result = asyncio.run(
+        scan_module.read_bacnet_points("1.2.3.4", 7, [("analogValue", 1)])
+    )
+
+    # then
+    assert result.success is False
+    assert result.data == []
+    assert result.error == "read failed"
+
+
+def test_read_bacnet_points_sync_uses_run_sync(monkeypatch) -> None:
+    # given
+    expected = object()
+
+    def _fake_run_sync(coro, *, timeout):
+        coro.close()
+        assert timeout == 60.0
+        return expected
+
+    monkeypatch.setattr(scan_module, "run_sync", _fake_run_sync)
+
+    # when
+    result = scan_module.read_bacnet_points_sync(
+        "1.2.3.4", 44, [("analogInput", 1)], timeout=30.0
+    )
+
+    # then
+    assert result is expected

--- a/tests/discovery/test_discovery_scan.py
+++ b/tests/discovery/test_discovery_scan.py
@@ -281,3 +281,189 @@ def test_scan_context_reads_library_version_from_source(monkeypatch) -> None:
     # then
     assert context["library_version"] == "0.2.0"
     assert context["client_ip"] == "10.0.0.2/24"
+
+
+# --- read_points tests ---
+
+
+def test_read_points_success(monkeypatch) -> None:
+    # given
+    captured: dict[str, str] = {}
+    raw_obj = FakeRawBACnetObject(
+        uid="bacnet://192.168.1.10/1001/analogValue:1",
+        object_identifier=FakeRawObjectIdentifier(
+            object_type="analogValue", instance=1
+        ),
+        device=FakeRawDeviceIdentifier(address="192.168.1.10", device_id=1001),
+        value=72.5,
+    )
+
+    def _fake_auto_detect(device_address: str | None = None) -> str:
+        captured["route_for"] = device_address or ""
+        return "192.168.1.2/24"
+
+    async def _fake_read_bacnet_points(address, device_id, points, **kwargs):
+        captured["address"] = address
+        captured["device_id"] = str(device_id)
+        captured["client_ip"] = kwargs.get("client_ip", "")
+        return SimpleNamespace(success=True, error=None, data=[raw_obj])
+
+    monkeypatch.setattr(scan_module, "auto_detect_client_ip", _fake_auto_detect)
+    monkeypatch.setattr(
+        "obs.discovery.bacnet.scan.read_bacnet_points",
+        _fake_read_bacnet_points,
+    )
+
+    # when
+    result = asyncio.run(
+        scan_module.read_points(
+            "bacnet://192.168.1.10#1001",
+            [("analogValue", 1)],
+            network="192.168.1.0/24",
+        )
+    )
+
+    # then
+    assert result.success is True
+    assert captured["route_for"] == "192.168.1.10"
+    assert captured["address"] == "192.168.1.10"
+    assert captured["device_id"] == "1001"
+    assert captured["client_ip"] == "192.168.1.2/24"
+    assert len(result.data.points) == 1
+    assert result.data.points[0].value == 72.5
+
+
+def test_read_points_returns_error_for_invalid_identifier() -> None:
+    # given
+    invalid_device = "not-a-valid-identifier"
+
+    # when
+    result = asyncio.run(scan_module.read_points(invalid_device, [("analogValue", 1)]))
+
+    # then
+    assert result.success is False
+    assert result.data.points == []
+    assert result.errors
+    assert result.error_details[0].code == "invalid_device_identifier"
+
+
+def test_read_points_returns_error_on_network_resolution_failure(monkeypatch) -> None:
+    # given
+    monkeypatch.setattr(
+        scan_module,
+        "detect_local_network",
+        lambda: (_ for _ in ()).throw(RuntimeError("no net")),
+    )
+
+    # when
+    result = asyncio.run(
+        scan_module.read_points(
+            "bacnet://192.168.1.10#1001",
+            [("analogValue", 1)],
+            strict=True,
+        )
+    )
+
+    # then
+    assert result.success is False
+    assert result.error_details[0].code == "network_resolution_failed"
+
+
+def test_read_points_returns_error_on_client_ip_resolution_failure(monkeypatch) -> None:
+    # given
+    monkeypatch.setattr(scan_module, "detect_local_network", lambda: "192.168.1.0/24")
+    monkeypatch.setattr(
+        scan_module,
+        "auto_detect_client_ip",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("no ip")),
+    )
+
+    # when
+    result = asyncio.run(
+        scan_module.read_points(
+            "bacnet://192.168.1.10#1001",
+            [("analogValue", 1)],
+            strict=True,
+        )
+    )
+
+    # then
+    assert result.success is False
+    assert result.error_details[0].code == "client_ip_resolution_failed"
+
+
+def test_read_points_handles_protocol_read_failure(monkeypatch) -> None:
+    # given
+    monkeypatch.setattr(
+        scan_module, "auto_detect_client_ip", lambda *_: "192.168.1.2/24"
+    )
+
+    async def _fake_read_bacnet_points(address, device_id, points, **kwargs):
+        return SimpleNamespace(success=False, error="device timeout", data=[])
+
+    monkeypatch.setattr(
+        "obs.discovery.bacnet.scan.read_bacnet_points",
+        _fake_read_bacnet_points,
+    )
+
+    # when
+    result = asyncio.run(
+        scan_module.read_points(
+            "bacnet://192.168.1.10#1001",
+            [("analogValue", 1)],
+        )
+    )
+
+    # then
+    assert result.success is False
+    assert "device timeout" in result.errors[0]
+    assert result.error_details[0].code == "protocol_read_failed"
+
+
+def test_read_points_handles_exception_during_read(monkeypatch) -> None:
+    # given
+    monkeypatch.setattr(
+        scan_module, "auto_detect_client_ip", lambda *_: "192.168.1.2/24"
+    )
+
+    async def _fake_read_bacnet_points(address, device_id, points, **kwargs):
+        raise RuntimeError("connection lost")
+
+    monkeypatch.setattr(
+        "obs.discovery.bacnet.scan.read_bacnet_points",
+        _fake_read_bacnet_points,
+    )
+
+    # when
+    result = asyncio.run(
+        scan_module.read_points(
+            "bacnet://192.168.1.10#1001",
+            [("analogValue", 1)],
+        )
+    )
+
+    # then
+    assert result.success is False
+    assert "connection lost" in result.errors[0]
+    assert result.error_details[0].code == "read_error"
+
+
+def test_read_points_sync_wrapper(monkeypatch) -> None:
+    # given
+    expected = object()
+
+    def _fake_run_sync(coro, *, timeout):
+        coro.close()
+        assert timeout == 60
+        return expected
+
+    monkeypatch.setattr("obs.discovery.bacnet._loop.run_sync", _fake_run_sync)
+
+    # when
+    result = scan_module.read_points_sync(
+        "bacnet://192.168.1.10#1001",
+        [("analogValue", 1)],
+    )
+
+    # then
+    assert result is expected


### PR DESCRIPTION
Fixes #10

## Summary
Add BACnet point value reading operations to retrieve current values from BACnet objects.

## Changes
- Add `ReadMixin` with `read_point` and `read_points` methods for retrieving current values from BACnet objects
- Implement RPM (ReadPropertyMultiple) support for efficient batch reads with automatic fallback to individual reads when RPM is not supported
- Add new types for point value responses in `types.py`
- Extend scan module with point reading capabilities
- Add public API functions `read_points()` and `read_points_sync()` for protocol-agnostic point reading
- Add `ReadPointsResult`, `ReadPointsInput`, `ReadPointsData` types

## Test Plan
- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR