### PR TITLE
ci: add automatic releases with python-semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "src/**"
+      - "pyproject.toml"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/**"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    concurrency: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Python Semantic Release
+        uses: python-semantic-release/python-semantic-release@v9
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,13 @@ jobs:
           python-version: "3.13"
 
       - name: Python Semantic Release
+        id: release
         uses: python-semantic-release/python-semantic-release@v9
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to PyPI
+        if: steps.release.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.0.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -89,14 +89,45 @@ Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/).
 # Install all dependencies (including AI extras for full test coverage)
 uv sync --extra network --extra ai
 
-# Set up pre-commit hooks
-pre-commit install
+# Set up pre-commit hooks (includes commit message validation)
+pre-commit install --hook-type pre-commit --hook-type commit-msg
 
 # Run tests
 uv run pytest
 
 # Run linters
 pre-commit run --all-files
+```
+
+### Commit Messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) for automatic versioning and release notes. Commit messages are validated by pre-commit hooks.
+
+**Format:** `<type>: <description>`
+
+| Type       | Description             | Version Bump  |
+|------------|-------------------------|---------------|
+| `feat`     | New feature             | Minor (0.X.0) |
+| `fix`      | Bug fix                 | Patch (0.0.X) |
+| `perf`     | Performance improvement | Patch (0.0.X) |
+| `docs`     | Documentation only      | No release    |
+| `style`    | Code style (formatting) | No release    |
+| `refactor` | Code refactoring        | No release    |
+| `test`     | Adding/updating tests   | No release    |
+| `ci`       | CI/CD changes           | No release    |
+| `chore`    | Maintenance tasks       | No release    |
+| `build`    | Build system changes    | No release    |
+
+**Examples:**
+```bash
+git commit -m "feat: add BACnet point reading"
+git commit -m "fix: resolve network timeout on slow devices"
+git commit -m "docs: update installation instructions"
+```
+
+**Breaking changes:** Add `!` after the type or include `BREAKING CHANGE:` in the body for major version bumps (X.0.0):
+```bash
+git commit -m "feat!: redesign discovery API"
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,3 +85,21 @@ dev = [
     "pre-commit>=4.0.0",
     "factory-boy>=3.3.3",
 ]
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+branch = "main"
+build_command = "pip install build && python -m build"
+commit_message = "chore(release): {version}"
+tag_format = "v{version}"
+
+[tool.semantic_release.commit_parser_options]
+allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"]
+minor_tags = ["feat"]
+patch_tags = ["fix", "perf"]
+
+[tool.semantic_release.remote]
+type = "github"
+
+[tool.semantic_release.publish]
+upload_to_vcs_release = true


### PR DESCRIPTION
Fixes #12 

Configure semantic-release to automatically:
- Analyze conventional commit messages
- Bump version in pyproject.toml
- Create git tags and GitHub releases

Triggers on push to main when src/ files change.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
