### PR TITLE
fix(bacnet): handle no-Who-Is-response devices + add direct ReadProperty side-channel (SCF-134)

### DIFF
--- a/src/obs/discovery/bacnet/controller/census.py
+++ b/src/obs/discovery/bacnet/controller/census.py
@@ -147,9 +147,9 @@ class CensusMixin:
             return None
         except IndexError as exc:
             # BAC0.readMultiple() needs an I-Am cached before sending RPM and
-            # indexes _iam[0]; devices that don't respond to Who-Is (e.g. Badger
-            # flow meters) raise IndexError here. Fall through so the caller can
-            # retry with per-property read(), which doesn't require I-Am.
+            # indexes _iam[0]; devices that don't respond to Who-Is raise
+            # IndexError here. Fall through so the caller can retry with
+            # per-property read(), which doesn't require I-Am.
             logger.warning(
                 "RPM unavailable for %s (no I-Am response from device): %s",
                 device_address,

--- a/src/obs/discovery/bacnet/controller/census.py
+++ b/src/obs/discovery/bacnet/controller/census.py
@@ -61,57 +61,35 @@ class CensusMixin:
                 logger.debug("Error parsing RPM census result: %s", exc)
 
         if device_name is None:
-            try:
-                name = await asyncio.wait_for(
-                    self.bacnet.read(f"{device_address} device:{device_id} objectName"),
-                    timeout=5.0,
-                )
-                device_name = str(name) if name else None
-            except BACNET_ERRORS:
-                pass
+            name = await self._read_device_property(
+                device_address, device_id, "objectName", timeout=5.0
+            )
+            device_name = str(name) if name else None
 
         if vendor is None:
-            try:
-                vendor_name = await asyncio.wait_for(
-                    self.bacnet.read(f"{device_address} device:{device_id} vendorName"),
-                    timeout=5.0,
-                )
-                vendor = str(vendor_name) if vendor_name else None
-            except BACNET_ERRORS:
-                pass
+            vendor_name = await self._read_device_property(
+                device_address, device_id, "vendorName", timeout=5.0
+            )
+            vendor = str(vendor_name) if vendor_name else None
 
         if model is None:
-            try:
-                model_name = await asyncio.wait_for(
-                    self.bacnet.read(f"{device_address} device:{device_id} modelName"),
-                    timeout=5.0,
-                )
-                model = str(model_name) if model_name else None
-            except BACNET_ERRORS:
-                pass
+            model_name = await self._read_device_property(
+                device_address, device_id, "modelName", timeout=5.0
+            )
+            model = str(model_name) if model_name else None
 
         if firmware is None:
-            try:
-                firmware_revision = await asyncio.wait_for(
-                    self.bacnet.read(
-                        f"{device_address} device:{device_id} firmwareRevision"
-                    ),
-                    timeout=5.0,
-                )
-                firmware = str(firmware_revision) if firmware_revision else None
-            except BACNET_ERRORS:
-                pass
+            firmware_revision = await self._read_device_property(
+                device_address, device_id, "firmwareRevision", timeout=5.0
+            )
+            firmware = str(firmware_revision) if firmware_revision else None
 
         if not object_list:
-            try:
-                obj_list_raw = await asyncio.wait_for(
-                    self.bacnet.read(f"{device_address} device:{device_id} objectList"),
-                    timeout=10.0,
-                )
-                if obj_list_raw:
-                    object_list = self._parse_object_list(obj_list_raw)
-            except BACNET_ERRORS:
-                pass
+            obj_list_raw = await self._read_device_property(
+                device_address, device_id, "objectList", timeout=10.0
+            )
+            if obj_list_raw:
+                object_list = self._parse_object_list(obj_list_raw)
 
         identifier = BACnetDeviceIdentifier(address=device_address, device_id=device_id)
         return BACnetDevice(
@@ -169,6 +147,45 @@ class CensusMixin:
                 logger.debug("RPM failed for %s: %s", device_address, exc)
                 return None
             raise
+
+    async def _read_device_property(
+        self,
+        device_address: str,
+        device_id: int,
+        property_name: str,
+        *,
+        timeout: float,
+    ) -> Any | None:
+        """Try BAC0.read(); if it fails, fall back to direct bacpypes3 ReadProperty.
+
+        BAC0's read() requires a cached I-Am, so devices that don't respond to
+        Who-Is fail even on individual reads. The direct path sends a unicast
+        ReadProperty to the known address with no discovery handshake.
+        """
+        try:
+            value = await asyncio.wait_for(
+                self.bacnet.read(
+                    f"{device_address} device:{device_id} {property_name}"
+                ),
+                timeout=timeout,
+            )
+            if value is not None:
+                return value
+        except BACNET_ERRORS as exc:
+            logger.debug(
+                "BAC0 read of %s on %s failed (%s); trying direct ReadProperty",
+                property_name,
+                device_address,
+                exc,
+            )
+
+        return await self.direct_read_property(  # type: ignore[attr-defined]
+            device_address,
+            "device",
+            device_id,
+            property_name,
+            timeout=timeout,
+        )
 
     def _parse_object_list(self, object_list_raw: Any) -> list[BACnetObjectIdentifier]:
         parsed: list[BACnetObjectIdentifier] = []

--- a/src/obs/discovery/bacnet/controller/census.py
+++ b/src/obs/discovery/bacnet/controller/census.py
@@ -145,6 +145,17 @@ class CensusMixin:
             if isinstance(result, dict):
                 return result
             return None
+        except IndexError as exc:
+            # BAC0.readMultiple() needs an I-Am cached before sending RPM and
+            # indexes _iam[0]; devices that don't respond to Who-Is (e.g. Badger
+            # flow meters) raise IndexError here. Fall through so the caller can
+            # retry with per-property read(), which doesn't require I-Am.
+            logger.warning(
+                "RPM unavailable for %s (no I-Am response from device): %s",
+                device_address,
+                exc,
+            )
+            return None
         except Exception as exc:
             error_name = type(exc).__name__
             if error_name in (

--- a/src/obs/discovery/bacnet/controller/core.py
+++ b/src/obs/discovery/bacnet/controller/core.py
@@ -10,13 +10,14 @@ from io import StringIO
 from typing import Any
 
 from .census import CensusMixin
+from .direct_read import DirectReadMixin
 from .network_scan import NetworkScanMixin
 from .object_scan import ObjectScanMixin
 
 logger = logging.getLogger(__name__)
 
 
-class BACnetController(NetworkScanMixin, CensusMixin, ObjectScanMixin):
+class BACnetController(NetworkScanMixin, CensusMixin, ObjectScanMixin, DirectReadMixin):
     """Singleton BAC0 wrapper for all BACnet operations."""
 
     def __init__(

--- a/src/obs/discovery/bacnet/controller/direct_read.py
+++ b/src/obs/discovery/bacnet/controller/direct_read.py
@@ -1,0 +1,101 @@
+"""Direct bacpypes3 ReadProperty side-channel.
+
+Bypasses BAC0's Who-Is / I-Am handshake by calling the underlying
+bacpypes3 Application.read_property() directly. Used as a tertiary
+fallback for devices that don't reply to Who-Is — for those, BAC0's
+own read() also fails because it caches I-Am before reading.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from bacpypes3.apdu import ErrorRejectAbortNack
+from bacpypes3.basetypes import PropertyIdentifier
+from bacpypes3.pdu import Address
+from bacpypes3.primitivedata import ObjectIdentifier
+
+logger = logging.getLogger(__name__)
+
+
+class DirectReadMixin:
+    """ReadProperty straight to a known address, no discovery."""
+
+    bacnet: Any
+
+    async def direct_read_property(
+        self,
+        device_address: str,
+        object_type: str,
+        instance: int,
+        property_name: str,
+        *,
+        timeout: float = 5.0,
+    ) -> Any | None:
+        """Read a single property via bacpypes3, bypassing BAC0's Who-Is.
+
+        Returns the raw property value, or None if the read fails.
+        """
+        if self.bacnet is None:
+            raise RuntimeError("BACnet controller not initialized")
+
+        app = self._bacpypes3_app()
+        if app is None:
+            logger.debug(
+                "Direct read unavailable: bacpypes3 application handle not exposed"
+            )
+            return None
+
+        try:
+            response = await asyncio.wait_for(
+                app.read_property(
+                    Address(device_address),
+                    ObjectIdentifier((object_type, instance)),
+                    PropertyIdentifier(property_name),
+                    None,
+                ),
+                timeout=timeout,
+            )
+        except (
+            ErrorRejectAbortNack,
+            TimeoutError,
+            asyncio.TimeoutError,
+            RuntimeError,
+            OSError,
+            ValueError,
+            TypeError,
+        ) as exc:
+            logger.debug(
+                "Direct read %s %s:%s.%s failed: %s",
+                device_address,
+                object_type,
+                instance,
+                property_name,
+                exc,
+            )
+            return None
+
+        if isinstance(response, ErrorRejectAbortNack):
+            logger.debug(
+                "Direct read %s %s:%s.%s returned error: %s",
+                device_address,
+                object_type,
+                instance,
+                property_name,
+                response,
+            )
+            return None
+        return response
+
+    def _bacpypes3_app(self) -> Any | None:
+        """Reach into BAC0 to grab the underlying bacpypes3 Application.
+
+        BAC0 layout: bacnet -> this_application (BAC0Application) -> app (bacpypes3 Application).
+        Returns None if the chain isn't there (e.g. in tests with a bare Mock).
+        """
+        this_application = getattr(self.bacnet, "this_application", None)
+        if this_application is None:
+            return None
+        return getattr(this_application, "app", None)

--- a/tests/discovery/bacnet/test_controller.py
+++ b/tests/discovery/bacnet/test_controller.py
@@ -200,6 +200,101 @@ def test_read_multiple_returns_none_when_bac0_iam_index_error(
     assert any("no I-Am response" in rec.message for rec in caplog.records)
 
 
+def test_direct_read_property_returns_value_via_bacpypes3_app(
+    initialized_controller: BACnetController, bacnet_mock: Mock
+) -> None:
+    # given — BAC0 exposes a bacpypes3 application via this_application.app.
+    bacpypes_app = Mock()
+    bacpypes_app.read_property = AsyncMock(return_value="DirectName")
+    bacnet_mock.this_application = Mock(app=bacpypes_app)
+
+    # when
+    result = asyncio.run(
+        initialized_controller.direct_read_property(
+            "1.2.3.4", "device", 42, "objectName"
+        )
+    )
+
+    # then
+    assert result == "DirectName"
+    assert bacpypes_app.read_property.await_count == 1
+
+
+def test_direct_read_property_returns_none_when_app_unavailable(
+    initialized_controller: BACnetController, bacnet_mock: Mock
+) -> None:
+    # given — no this_application attribute on the BAC0 handle.
+    bacnet_mock.this_application = None
+
+    # when
+    result = asyncio.run(
+        initialized_controller.direct_read_property(
+            "1.2.3.4", "device", 42, "objectName"
+        )
+    )
+
+    # then
+    assert result is None
+
+
+def test_direct_read_property_swallows_read_errors(
+    initialized_controller: BACnetController, bacnet_mock: Mock
+) -> None:
+    # given
+    bacpypes_app = Mock()
+    bacpypes_app.read_property = AsyncMock(side_effect=RuntimeError("no response"))
+    bacnet_mock.this_application = Mock(app=bacpypes_app)
+
+    # when
+    result = asyncio.run(
+        initialized_controller.direct_read_property(
+            "1.2.3.4", "device", 42, "objectName"
+        )
+    )
+
+    # then
+    assert result is None
+
+
+def test_direct_read_property_raises_when_not_initialized() -> None:
+    # given
+    controller = BACnetController(client_ip="1.1.1.1/24")
+    controller.bacnet = None
+
+    # when / then
+    try:
+        asyncio.run(
+            controller.direct_read_property("1.2.3.4", "device", 1, "objectName")
+        )
+        assert False, "Expected RuntimeError"
+    except RuntimeError as exc:
+        assert "not initialized" in str(exc)
+
+
+def test_census_uses_direct_read_when_bac0_read_fails(
+    initialized_controller: BACnetController, bacnet_mock: Mock
+) -> None:
+    # given — RPM crashes (IndexError), BAC0.read() also fails (I-Am cache empty),
+    # but the direct bacpypes3 ReadProperty returns values.
+    bacnet_mock.readMultiple.side_effect = IndexError("list index out of range")
+    bacnet_mock.read = AsyncMock(side_effect=RuntimeError("NoResponseFromController"))
+    bacpypes_app = Mock()
+    bacpypes_app.read_property = AsyncMock(
+        side_effect=["NameDirect", "VendorDirect", "ModelDirect", "1.2.3", []]
+    )
+    bacnet_mock.this_application = Mock(app=bacpypes_app)
+
+    # when
+    device = asyncio.run(initialized_controller.read_device_census("1.2.3.4", 42))
+
+    # then
+    assert device.name == "NameDirect"
+    assert device.vendor == "VendorDirect"
+    assert device.model == "ModelDirect"
+    assert device.firmware == "1.2.3"
+    assert bacpypes_app.read_property.await_count == 5
+
+
 def test_read_device_census_falls_back_when_rpm_hits_iam_index_error(
     initialized_controller: BACnetController, bacnet_mock: Mock
 ) -> None:

--- a/tests/discovery/bacnet/test_controller.py
+++ b/tests/discovery/bacnet/test_controller.py
@@ -178,6 +178,50 @@ def test_read_multiple_returns_none_on_exception(
     assert result is None
 
 
+def test_read_multiple_returns_none_when_bac0_iam_index_error(
+    initialized_controller: BACnetController, bacnet_mock: Mock, caplog
+) -> None:
+    # given — BAC0.readMultiple() indexes _iam[0] before sending RPM; devices
+    # that never reply to Who-Is (e.g. Badger flow meters) trigger IndexError.
+    bacnet_mock.readMultiple.side_effect = IndexError("list index out of range")
+
+    # when
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        result = asyncio.run(
+            initialized_controller.read_multiple(
+                "1.2.3.4", {"device:1": ["objectName"]}
+            )
+        )
+
+    # then
+    assert result is None
+    assert any("no I-Am response" in rec.message for rec in caplog.records)
+
+
+def test_read_device_census_falls_back_when_rpm_hits_iam_index_error(
+    initialized_controller: BACnetController, bacnet_mock: Mock
+) -> None:
+    # given — RPM fails with IndexError (no I-Am), but individual reads succeed.
+    bacnet_mock.readMultiple.side_effect = IndexError("list index out of range")
+    bacnet_mock.read = AsyncMock(
+        side_effect=["Badger-1", "Badger", "M-2000", "1.0", [("analogInput", 1)]]
+    )
+
+    # when
+    device = asyncio.run(initialized_controller.read_device_census("1.2.3.4", 42))
+
+    # then
+    assert device.name == "Badger-1"
+    assert device.vendor == "Badger"
+    assert device.model == "M-2000"
+    assert device.firmware == "1.0"
+    assert device.object_list == [
+        BACnetObjectIdentifier(object_type="analogInput", instance=1)
+    ]
+
+
 def test_read_multiple_returns_none_for_non_dict_result(
     initialized_controller: BACnetController, bacnet_mock: Mock
 ) -> None:

--- a/tests/discovery/bacnet/test_controller.py
+++ b/tests/discovery/bacnet/test_controller.py
@@ -182,7 +182,7 @@ def test_read_multiple_returns_none_when_bac0_iam_index_error(
     initialized_controller: BACnetController, bacnet_mock: Mock, caplog
 ) -> None:
     # given — BAC0.readMultiple() indexes _iam[0] before sending RPM; devices
-    # that never reply to Who-Is (e.g. Badger flow meters) trigger IndexError.
+    # that never reply to Who-Is trigger IndexError.
     bacnet_mock.readMultiple.side_effect = IndexError("list index out of range")
 
     # when
@@ -206,15 +206,15 @@ def test_read_device_census_falls_back_when_rpm_hits_iam_index_error(
     # given — RPM fails with IndexError (no I-Am), but individual reads succeed.
     bacnet_mock.readMultiple.side_effect = IndexError("list index out of range")
     bacnet_mock.read = AsyncMock(
-        side_effect=["Badger-1", "Badger", "M-2000", "1.0", [("analogInput", 1)]]
+        side_effect=["Dev-1", "Vendor", "M-2000", "1.0", [("analogInput", 1)]]
     )
 
     # when
     device = asyncio.run(initialized_controller.read_device_census("1.2.3.4", 42))
 
     # then
-    assert device.name == "Badger-1"
-    assert device.vendor == "Badger"
+    assert device.name == "Dev-1"
+    assert device.vendor == "Vendor"
     assert device.model == "M-2000"
     assert device.firmware == "1.0"
     assert device.object_list == [


### PR DESCRIPTION
## Summary
Two-layer fix for devices that don't respond to BACnet Who-Is.

### Layer 1 — stop the crash (commit `a347e20`)
`BAC0.readMultiple()` indexes `_iam[0]` before sending RPM. Devices that don't reply to Who-Is raise `IndexError`, which propagated out of `read_multiple()` and crashed the device census. Now caught narrowly inside `census.py::read_multiple()` with a WARNING log so production can see degradation; the shared `BACNET_ERRORS` tuple is deliberately not broadened.

### Layer 2 — actually read from those devices (commit `3ca31fc`)
Field testing revealed BAC0's individual `read()` also requires a cached I-Am — the device's over-the-wire reply is discarded with `Trouble with Iam... Response received from <ip> = []` and the fallback returned `NoResponseFromController`. This is a BAC0 architectural limit.

Added `DirectReadMixin` (`controller/direct_read.py`) that reaches BAC0's underlying `bacpypes3` Application via `bacnet.this_application.app` and sends a unicast `ReadProperty` with no discovery handshake. Refactored the per-property fallback in `read_device_census` into a single helper that tries `BAC0.read()` first and falls through to the direct path when `BACNET_ERRORS` fire — so normal devices keep their current behavior and only failures trigger the new path.

Resolves [SCF-134](https://linear.app/skycentrics/issue/SCF-134/fix-bacnet-read-issue-when-a-device-does-not-respond-to-who-is-i-am).

## Flow
```
read_multiple()         # BAC0 RPM
  → on None/IndexError:
    bacnet.read()       # BAC0 individual read
      → on BACNET_ERRORS:
        direct_read_property()   # NEW: bacpypes3 unicast ReadProperty
```

## Design notes
- No new dependency: uses `bacpypes3` which is already pulled in by BAC0.
- `DirectReadMixin` is a separate file/mixin to keep its bacpypes3 imports out of the BAC0-centric code paths and make it trivially testable in isolation.
- The mixin gracefully degrades if `this_application.app` isn't available (returns None), so test doubles using a bare `Mock` continue to work.
- Errors in the direct path are logged at DEBUG, not WARNING — the upstream Layer-1 WARNING already fires when degradation starts; the direct path's failure is just the final tier.

## Test plan
- [x] `test_read_multiple_returns_none_when_bac0_iam_index_error` — Layer-1 catch + WARNING.
- [x] `test_direct_read_property_returns_value_via_bacpypes3_app` — direct path returns the value bacpypes3 returns.
- [x] `test_direct_read_property_returns_none_when_app_unavailable` — graceful degrade.
- [x] `test_direct_read_property_swallows_read_errors` — exceptions don't propagate.
- [x] `test_direct_read_property_raises_when_not_initialized` — usual initialization guard.
- [x] `test_census_uses_direct_read_when_bac0_read_fails` — end-to-end: RPM fails → BAC0 read fails → direct read populates the device.
- [x] `test_read_device_census_falls_back_when_rpm_hits_iam_index_error` — existing fallback still works when BAC0 read does succeed.
- [x] Full test suite: 140 passed (was 133 on main).
- [ ] **Field verification on a real non-responsive device** — confirm the direct ReadProperty path actually returns values for the device class that triggered SCF-134.